### PR TITLE
Update PSClassUtils.psm1 and ClassUtils.Write-CUClassDiagram.Tests.ps1 for Linux support.

### DIFF
--- a/PsClassUtils/PSClassUtils.psm1
+++ b/PsClassUtils/PSClassUtils.psm1
@@ -15,7 +15,7 @@ foreach ($Private in $PrivateFunctions){
 }
 
 write-verbose "Loading Public Functions"
-$PublicFunctions = gci "$ScriptPath\Functions\public" -Filter *.ps1 | Select -Expand FullName
+$PublicFunctions = gci "$ScriptPath\Functions\Public" -Filter *.ps1 | Select -Expand FullName
 
 
 foreach ($public in $PublicFunctions){
@@ -27,7 +27,7 @@ foreach ($public in $PublicFunctions){
     }
 }
 
-$PrivateClasses = gci "$ScriptPath\Classes\Private" -Filter *.ps1 | sort Name | Select -Expand FullName
+$PrivateClasses = gci "$ScriptPath\Classes\Private" -Filter *.ps1 | Sort-Object Name | Select -Expand FullName
 
 
 foreach ($Private in $PrivateClasses){

--- a/Tests/ClassUtils.Write-CUClassDiagram.Tests.ps1
+++ b/Tests/ClassUtils.Write-CUClassDiagram.Tests.ps1
@@ -94,7 +94,7 @@ Describe "Testing Write-CUClassDiagram" {
              
     
             $FolderPathFolder = Join-Path -Path $Testdrive -ChildPath "FolderPath"
-            $null = mkdir $FolderPathFolder -Force
+            $null = New-Item -ItemType Directory -Path $FolderPathFolder -Force
             $Path_File1 = Join-Path -Path $FolderPathFolder -ChildPath "woop.ps1"
             $File1 | Out-File -FilePath $Path_File1 -Force
     
@@ -122,7 +122,7 @@ Describe "Testing Write-CUClassDiagram" {
         it "Parameter: -ExportPath: 'Should throw if folder does not exist'" {
             $Guid = [Guid]::NewGuid().Guid
             $NewFolder = Join-Path -Path $Testdrive -ChildPath $Guid
-            $null = mkdir $NewFolder
+            $null = New-Item -ItemType Directory -Path $NewFolder
             $ret = Write-CUClassDiagram -Path $ClassScript -ExportFolder $NewFolder
             $Ret.DirectoryName | should be $NewFolder
         }
@@ -130,7 +130,7 @@ Describe "Testing Write-CUClassDiagram" {
         it "Parameter: -ExportPath: 'Should Create a graph in Other folder'" {
             $Guid = [Guid]::NewGuid().Guid
             $NewFolder = Join-Path -Path $Testdrive -ChildPath $Guid
-            $null = mkdir $NewFolder -force
+            $null = New-Item -ItemType Directory -Path $NewFolder -force
             $ret = Write-CUClassDiagram -Path $ClassScript -ExportFolder $NewFolder
             $Ret.DirectoryName | should be $NewFolder
         }
@@ -190,7 +190,7 @@ Describe "Testing Write-CUClassDiagram" {
 '@
 
             $FolderPathFolder = Join-Path -Path $Testdrive -ChildPath "FolderPath"
-            $null = mkdir $FolderPathFolder -Force
+            $null = New-Item -ItemType Directory -Path $FolderPathFolder -Force
             $Path_File1 = Join-Path -Path $FolderPathFolder -ChildPath "woop.ps1"
             $File1 | Out-File -FilePath $Path_File1 -Force
 
@@ -218,7 +218,7 @@ Describe "Testing Write-CUClassDiagram" {
         it "Parameter: -ExportPath: 'Should throw if folder does not exist'" {
             $Guid = [Guid]::NewGuid().Guid
             $NewFolder = Join-Path -Path $Testdrive -ChildPath $Guid
-            $null = mkdir $NewFolder -Force
+            $null = New-Item -ItemType Directory -Path $NewFolder -Force
             $ret = Write-CUClassDiagram -Path $ClassScript -ExportFolder $NewFolder
             $Ret.DirectoryName | should be $NewFolder
         }
@@ -226,7 +226,7 @@ Describe "Testing Write-CUClassDiagram" {
         it "Parameter: -ExportPath: 'Should Create a graph in Other folder'" {
             $Guid = [Guid]::NewGuid().Guid
             $NewFolder = Join-Path -Path $Testdrive -ChildPath $Guid
-            $null = mkdir $NewFolder
+            $null = New-Item -ItemType Directory -Path $NewFolder
             $ret = Write-CUClassDiagram -Path $ClassScript -ExportFolder $NewFolder
             $Ret.DirectoryName | should be $NewFolder
         }


### PR DESCRIPTION
Changed sort and mkdir to Sort-Object and New-Item -ItemType Directory to correct issues on Linux. PowerShell core does not create aliases that are native commands for a platform.

Fixed an issue where a path was broken because the Linux file system is case sensitive.

This is in support of issue #34 