### PR TITLE
Added check for PSCORE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 PSClassUtils/Functions/Private/Out-CUPSGraph.1.ps1
 Tests/woop.ps1
 Tests/test_graph.ps1
+PSClassUtils/Classes/Private/00_CUClassParameter.psm1

--- a/PSClassUtils/Functions/Public/Get-CUClass.ps1
+++ b/PSClassUtils/Functions/Public/Get-CUClass.ps1
@@ -8,7 +8,7 @@ function Get-CUClass {
     .PARAMETER ClassName
         Specify the name of the class.
     .PARAMETER Path
-        The path of a file containing PowerShell Classes.
+        The path of a file containing PowerShell Classes. Accept values from the pipeline.
     .PARAMETER Raw
         The raw switch will display the raw content of the Class.
     .EXAMPLE
@@ -55,6 +55,10 @@ function Get-CUClass {
     }
 
     PROCESS {
+        
+        If ( ($Null -eq $PSBoundParameters['Path']) -And ($PSVersionTable.PSEdition -eq 'Core' ) ) {
+            Throw 'This feature is not supported on PSCore, due to missing DotNet libraries. Please use -Path instead...'
+        }
 
         $ClassParams = @{}
 


### PR DESCRIPTION
Fetching in PSSession loaded classes in PSCORE is not supported, due to missing dotnet librairies !
Users on PScore have to use the -Path parameter, or use the pipeline !