### PR TITLE
Fixes #122

### DIFF
--- a/Code/Functions/Public/Write-CUPesterTest.ps1
+++ b/Code/Functions/Public/Write-CUPesterTest.ps1
@@ -375,7 +375,7 @@ Function Write-CUPesterTest {
 
                 [void]$sb.AppendLine($visibility)
 
-                If ($Method.ReturnType -eq '[void]' -or $Null -eq $Method.ReturnType) {
+                If (!($Method.ReturnType) -or $Method.ReturnType -eq '[void]') {
                     [void]$sb.AppendLine("It '[$($Class.Name)] --> $($Method.Name)$($Signature) Should not return anything (voided)' {")
                 }
                 else {
@@ -422,7 +422,7 @@ Function Write-CUPesterTest {
                 
                 [void]$sb.AppendLine("# -- Assert")
                 [void]$sb.AppendLine("")
-                If ($Method.ReturnType -eq '[void]' -or $Null -eq $Method.ReturnType) {
+                If (!($Method.ReturnType) -or $Method.ReturnType -eq '[void]') {
                     [void]$sb.AppendLine("$MethodCall" + '| Should -Be $null')
                 }
                 else {


### PR DESCRIPTION
Methods with undefined return type should not be tested for type. They should rather be treated like void methods.

This was already attempted by comparing the return type with "[void]" or $null. With an undefined return type, however, the ReturnType property (from CUClassMethod) turns out to be an empty string ("").

By making a small adjustment to two if sentences, methods with an undefined return type are no longer type tested.